### PR TITLE
Rename the source type to `fastly:request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This Splunk app is compatible with the [Splunk Common Information Model (CIM)](h
 
 ## Source types
 
-| Source type | Description                                                                                                                                                                                            |
-|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `fastly`    | Fastly service request logs. See the ["Fastly Logging Format" proposal](https://docs.google.com/document/d/1QEziLUj-UcSfju9zhvvBeOq6sl5taOwGxLVjSALPCgA/edit) for documentation on the message format. |
+| Source type      | Description                                                                                                                                                                                            |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `fastly:request` | Fastly service request logs. See the ["Fastly Logging Format" proposal](https://docs.google.com/document/d/1QEziLUj-UcSfju9zhvvBeOq6sl5taOwGxLVjSALPCgA/edit) for documentation on the message format. |
 
 ## Releasing
 

--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -4,7 +4,7 @@
 # See https://docs.splunk.com/Documentation/Splunk/9.0.0/Admin/Propsconf for the file specification.
 #
 
-[fastly]
+[fastly:request]
 category = Structured
 description = Fastly real-time log streaming to the Splunk HTTP Event Collector
 


### PR DESCRIPTION
Later on we may want to consider other source types for logs coming out of Fastly, such as logs from Compute@Edge applications or from the legacy WAF product.