### PR TITLE
Sanitise any `x-api-key` URL parameter values

### DIFF
--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -11,7 +11,10 @@ description = Fastly real-time log streaming to the Splunk HTTP Event Collector
 INDEXED_EXTRACTIONS = JSON
 KV_MODE = none
 
-EXTRACT-url = https?:\/\/(?<url_domain>[^\/]+)(?<uri_path>[^?]+)(?<uri_query>\?[^#]+)? in url
+# Sanitise data before indexing, e.g. stripping x-api-key URL param values.
+SEDCMD-sanitise_url_x_api_key_param = s/x-api-key=\w+/x-api-key=***/g
+
+EXTRACT-url_domain,uri_path,uri_query = https?:\/\/(?<url_domain>[^\/]+)(?<uri_path>[^?]+)(?<uri_query>\?[^#]+)? in url
 
 EVAL-bytes = bytes_in + bytes_out
 EVAL-vendor_product = "Fastly"


### PR DESCRIPTION
Having a go at introducing data sanitation ahead of us updating Fastly services to log to the `fastly` index with the new format.

Here's how messages will be edited before being indexed by Splunk.

| Before                                            | After                                |
|---------------------------------------------------|--------------------------------------|
| `https://example.com/?x-api-key=0000000000000000` | `https://example.com/?x-api-key=***` |

Documentation on the approach is available at https://docs.splunk.com/Documentation/Splunk/9.0.0/Data/Anonymizedata, an alternative to using `SEDCMD` is to use a transform, but as the end result seems the same I've picked the approach that involves less configuration.

With `SEDCMD` there is no way to limit the replacement to only the `url` field, should be okay for this case but worth being mindful of when building regexes that might match on other fields unintentionally for whatever reason.

This also updates the name of the `EXTRACT` for the url field to include the names of the extracted fields.