### PR TITLE
Add `fastly:waf` source type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 Support for [Fastly's real-time log streaming](https://docs.fastly.com/en/guides/about-fastlys-realtime-log-streaming-features) packaged as a Splunk app.
 
-This Splunk app is compatible with the [Splunk Common Information Model (CIM)](https://docs.splunk.com/Documentation/CIM/5.0.1/User/Overview) for [Web](https://docs.splunk.com/Documentation/CIM/5.0.1/User/Web).
+This Splunk app is compatible with the [Splunk Common Information Model (CIM)](https://docs.splunk.com/Documentation/CIM/5.0.1/User/Overview) for [Web](https://docs.splunk.com/Documentation/CIM/5.0.1/User/Web) and [Intrusion Detection](https://docs.splunk.com/Documentation/CIM/5.0.1/User/IntrusionDetection).
 
 ## Source types
 
-| Source type      | Description                                                                                                                                                                                            |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `fastly:request` | Fastly service request logs. See the ["Fastly Logging Format" proposal](https://docs.google.com/document/d/1QEziLUj-UcSfju9zhvvBeOq6sl5taOwGxLVjSALPCgA/edit) for documentation on the message format. |
+<!-- Update this table using https://www.tablesgenerator.com/markdown_tables. -->
+
+| Source type      | Description          |
+|------------------|----------------------|
+| `fastly:request` | Fastly request logs. |
+| `fastly:waf`     | Fastly WAF logs.     |
 
 ## Releasing
 

--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -6,7 +6,7 @@
 
 [fastly:request]
 category = Structured
-description = Fastly real-time log streaming to the Splunk HTTP Event Collector
+description = Fastly request log streaming to the Splunk HTTP Event Collector
 
 INDEXED_EXTRACTIONS = JSON
 KV_MODE = none
@@ -20,3 +20,24 @@ EVAL-bytes = bytes_in + bytes_out
 EVAL-vendor_product = "Fastly"
 
 FIELDALIAS-http_referer = http_referer AS http_referrer
+
+[fastly:waf]
+category = Structured
+description = Fastly legacy WAF log streaming to the Splunk HTTP Event Collector
+
+INDEXED_EXTRACTIONS = JSON
+KV_MODE = none
+
+# See https://docs.fastly.com/en/guides/fastly-waf-logging-legacy for details on the `waf_*` field values.
+
+EXTRACT-url_domain,uri_path,uri_query = https?:\/\/(?<url_domain>[^\/]+)(?<uri_path>[^?]+)(?<uri_query>\?[^#]+)? in url
+
+EVAL-severity = case(severity_id<=1, "critical", severity_id<=3, "high", severity_id<=4, "medium", severity_id<=7, "low", severity_id==99, "informational")
+
+EVAL-ids_type = "network"
+EVAL-transport = "tcp"
+EVAL-vendor = "Fastly"
+EVAL-vendor_product = "Fastly WAF"
+
+FIELDALIAS-dest = host AS dest
+FIELDALIAS-file_path = url AS file_path

--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -17,7 +17,8 @@ SEDCMD-sanitise_url_x_api_key_param = s/x-api-key=\w+/x-api-key=***/g
 EXTRACT-url_domain,uri_path,uri_query = https?:\/\/(?<url_domain>[^\/]+)(?<uri_path>[^?]+)(?<uri_query>\?[^#]+)? in url
 
 EVAL-bytes = bytes_in + bytes_out
-EVAL-vendor_product = "Fastly"
+EVAL-vendor = "Fastly"
+EVAL-vendor_product = "Fastly Deliver"
 
 FIELDALIAS-http_referer = http_referer AS http_referrer
 

--- a/app/default/tags.conf
+++ b/app/default/tags.conf
@@ -4,6 +4,10 @@
 # See https://docs.splunk.com/Documentation/Splunk/9.0.0/Admin/Tagsconf for the file specification.
 #
 
-[sourcetype=fastly]
+[sourcetype=fastly:request]
 web = enabled
 proxy = enabled
+
+[sourcetype=fastly:waf]
+ids = enabled
+attack = enabled


### PR DESCRIPTION
Based on the [CIM for Intrusion Detection](https://docs.splunk.com/Documentation/CIM/5.0.1/User/IntrusionDetection).

This would replace the Apto built app, `apto_TA_fastly`, which doesn't seem to be configured to set the WAF logs as IDS CIM events.

Pairs with the [logging formats](https://gist.github.com/sjparkinson/355668871986e985b3d50563554373c3) that will be rolled out to all Fastly services.